### PR TITLE
upload only filename without full path

### DIFF
--- a/api/upload.go
+++ b/api/upload.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path"
 	"regexp"
 	"time"
 
@@ -47,7 +48,7 @@ func NewUploadOptionsFromFile(file *os.File) (*UploadOptions, error) {
 		Stream:   file,
 		FileSize: info.Size(),
 
-		Name:      file.Name(),
+		Name:      path.Base(file.Name()),
 		Timestamp: info.ModTime().Unix() * 1000,
 	}, nil
 }


### PR DESCRIPTION
Hi, I tried your program and found the problem of uploaded name, When I upload, for example,

/home/myusername/test.jpg

The name showed on Google Photos is */home/myusername/test.jpg*, not *test.jpg*.

I think most users do not need full path in the name of their photo, so I create this pull request to fix this issue.